### PR TITLE
Fully support array parameters in private requests

### DIFF
--- a/src/IndependentReserve/PrivateClient.php
+++ b/src/IndependentReserve/PrivateClient.php
@@ -59,7 +59,7 @@ class PrivateClient extends PublicClient
         $res = $url;
         foreach ($data as $key => $value) {
             if (is_array($value)) {
-                $res .= ",$key=".array_values($value)[0]; // works only for case when array has one value. And no docs how to use for array with more then one value
+                $res .= ",$key=".implode(",",$value); // works for all arrays
             } else {
                 $res .= ",$key=$value";
             }


### PR DESCRIPTION
Now it will work even with arrays that have more than one parameter

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/independentreserve/17)
<!-- Reviewable:end -->
