### PR TITLE
Litecoin support 202003

### DIFF
--- a/src/IndependentReserve/Currency.php
+++ b/src/IndependentReserve/Currency.php
@@ -5,9 +5,9 @@ namespace IndependentReserve;
 class Currency
 {
     /**
-     * Bitcoin.
+     * Australian Dollar.
      */
-    const XBT = 'Xbt';
+    const AUD = 'Aud';
 
     /**
      * US Dollar.
@@ -15,19 +15,24 @@ class Currency
     const USD = 'Usd';
 
     /**
-     * Australian Dollar.
-     */
-    const AUD = 'Aud';
-
-    /**
      * New Zealand Dollar.
      */
     const NZD = 'Nzd';
 
     /**
-     * Etherium.
+     * Bitcoin.
+     */
+    const XBT = 'Xbt';
+
+    /**
+     * Ethereum.
      */
     const ETH = 'Eth';
+
+    /**
+     * Ripple.
+     */
+    const XRP = 'Xrp';
 
     /**
      * Bitcoin Cash.
@@ -35,7 +40,62 @@ class Currency
     const BCH = 'Bch';
 
     /**
+     * Bitcoin SV.
+     */
+    const BSV = 'Bsv';
+
+    /**
+     * Tether USD.
+     */
+    const USDT = 'Usdt';
+
+    /**
      * Litecoin.
      */
     const LTC = 'Ltc';
+
+    /**
+     * EOS.
+     */
+    const EOS = 'Eos';
+
+    /**
+     * Stellar Lumens.
+     */
+    const XLM = 'Xlm';
+
+    /**
+     * Ethereum Classic.
+     */
+    const ETC = 'Etc';
+
+    /**
+     * Basic Attention Token.
+     */
+    const BAT = 'Bat';
+
+    /**
+     * OmiseGO.
+     */
+    const OMG = 'Omg';
+
+    /**
+     * Augur.
+     */
+    const REP = 'Rep';
+
+    /**
+     * 0x.
+     */
+    const ZRX = 'Zrx';
+
+    /**
+     * Golem.
+     */
+    const GNT = 'Gnt';
+
+    /**
+     * PlayChip.
+     */
+    const PLA = 'Pla';
 }

--- a/tests/integration/IndependentReserve/ClientIntegrationPublicTest.php
+++ b/tests/integration/IndependentReserve/ClientIntegrationPublicTest.php
@@ -20,13 +20,13 @@ class ClientIntegrationPublicTest extends TestCase
     public function testGetValidPrimaryCurrencyCodes()
     {
         $currencyCodes = $this->client->getValidPrimaryCurrencyCodes();
-        $this->assert($currencyCodes, equals, [Currency::XBT, Currency::ETH, Currency::BCH, Currency::LTC]);
+        $this->assert($currencyCodes, equals, [Currency::XBT, Currency::ETH, Currency::XRP, Currency::BCH, Currency::BSV, Currency::USDT, Currency::LTC, Currency::EOS, Currency::XLM, Currency::ETC, Currency::BAT, Currency::OMG, Currency::REP, Currency::ZRX, Currency::GNT, Currency::PLA]);
     }
 
     public function testGetValidSecondaryCurrencyCodes()
     {
         $currencyCodes = $this->client->getValidSecondaryCurrencyCodes();
-        $this->assert($currencyCodes, equals, [Currency::USD, Currency::AUD, Currency::NZD]);
+        $this->assert($currencyCodes, equals, [Currency::AUD, Currency::USD, Currency::NZD]);
     }
 
     public function testGetValidLimitOrderTypes()

--- a/tests/unit/IndependentReserve/CurrencyTest.php
+++ b/tests/unit/IndependentReserve/CurrencyTest.php
@@ -36,11 +36,6 @@ class CurrencyTest extends TestCase
         $this->assert(Currency::XRP, equals, 'Xrp');
     }
 
-    public function testXrp()
-    {
-        $this->assert(Currency::XRP, equals, 'Xrp');
-    }
-
     public function testBch()
     {
         $this->assert(Currency::BCH, equals, 'Bch');
@@ -49,11 +44,6 @@ class CurrencyTest extends TestCase
     public function testBsv()
     {
         $this->assert(Currency::BSV, equals, 'Bsv');
-    }
-
-    public function testUsdt()
-    {
-        $this->assert(Currency::USDT, equals, 'Usdt');
     }
 
     public function testUsdt()

--- a/tests/unit/IndependentReserve/CurrencyTest.php
+++ b/tests/unit/IndependentReserve/CurrencyTest.php
@@ -6,9 +6,9 @@ use Concise\TestCase;
 
 class CurrencyTest extends TestCase
 {
-    public function testXbt()
+    public function testAud()
     {
-        $this->assert(Currency::XBT, equals, 'Xbt');
+        $this->assert(Currency::AUD, equals, 'Aud');
     }
 
     public function testUsd()
@@ -16,14 +16,14 @@ class CurrencyTest extends TestCase
         $this->assert(Currency::USD, equals, 'Usd');
     }
 
-    public function testAud()
-    {
-        $this->assert(Currency::AUD, equals, 'Aud');
-    }
-
     public function testNzd()
     {
         $this->assert(Currency::NZD, equals, 'Nzd');
+    }
+
+    public function testXbt()
+    {
+        $this->assert(Currency::XBT, equals, 'Xbt');
     }
 
     public function testEth()
@@ -31,14 +31,83 @@ class CurrencyTest extends TestCase
         $this->assert(Currency::ETH, equals, 'Eth');
     }
 
+    public function testXrp()
+    {
+        $this->assert(Currency::XRP, equals, 'Xrp');
+    }
+
+    public function testXrp()
+    {
+        $this->assert(Currency::XRP, equals, 'Xrp');
+    }
+
     public function testBch()
     {
         $this->assert(Currency::BCH, equals, 'Bch');
+    }
+
+    public function testBsv()
+    {
+        $this->assert(Currency::BSV, equals, 'Bsv');
+    }
+
+    public function testUsdt()
+    {
+        $this->assert(Currency::USDT, equals, 'Usdt');
+    }
+
+    public function testUsdt()
+    {
+        $this->assert(Currency::USDT, equals, 'Usdt');
     }
 
     public function testLtc()
     {
         $this->assert(Currency::LTC, equals, 'Ltc');
     }
-}
 
+    public function testEos()
+    {
+        $this->assert(Currency::EOS, equals, 'Eos');
+    }
+
+    public function testXlm()
+    {
+        $this->assert(Currency::XLM, equals, 'Xlm');
+    }
+
+    public function testEtc()
+    {
+        $this->assert(Currency::ETC, equals, 'Etc');
+    }
+
+    public function testBat()
+    {
+        $this->assert(Currency::BAT, equals, 'Bat');
+    }
+
+    public function testOmg()
+    {
+        $this->assert(Currency::OMG, equals, 'Omg');
+    }
+
+    public function testRep()
+    {
+        $this->assert(Currency::REP, equals, 'Rep');
+    }
+
+    public function testZrx()
+    {
+        $this->assert(Currency::ZRX, equals, 'Zrx');
+    }
+
+    public function testGnt()
+    {
+        $this->assert(Currency::GNT, equals, 'Gnt');
+    }
+
+    public function testPla()
+    {
+        $this->assert(Currency::PLA, equals, 'Pla');
+    }
+}


### PR DESCRIPTION
Brings litecoin support current to 2020-03.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/independentreserve/18)
<!-- Reviewable:end -->
